### PR TITLE
Improve search results

### DIFF
--- a/js/export.js
+++ b/js/export.js
@@ -61,7 +61,7 @@ $(document).ready(function () {
             return;
         } else(exportActive = true);
 
-        //Reset some of the global values when the start-button is clicked 
+        //Reset some of the global values when the start-button is clicked
         globalArtists = [];
         playlistID = null;
         multipleMatches = [];
@@ -177,8 +177,8 @@ function multipleMatch(release, matches) {
 
 
 
-/** We don't want duplicate artists in the global array, so this method checks 
-if the array contains the given artist (by name) and returns either the position 
+/** We don't want duplicate artists in the global array, so this method checks
+if the array contains the given artist (by name) and returns either the position
 in the array or -1. */
 function artistsContainsName(name) {
 
@@ -320,7 +320,7 @@ function addArtistsAndReleases(result) {
 
         } else {
 
-            //Create new artist with new release-array and add artist to the global array      
+            //Create new artist with new release-array and add artist to the global array
             globalArtists.push(new artist(releaseArtistName, new Array(thisRelease)));
             totalReleases++;
             totalArtists++;
@@ -413,7 +413,7 @@ function exportToSpotify() {
 }
 
 
-/** Helper function that calculates the progress based on the number of already exported artists and then 
+/** Helper function that calculates the progress based on the number of already exported artists and then
  * sets a timeout until the next *artist gets exported. This leaves time for the browser to display the updated
  * progress bar and the cover images */
 function updateProgress() {
@@ -428,7 +428,7 @@ function updateProgress() {
 }
 
 
-/** If there are releases with multiple possible matches, we display a modal to make the user decide 
+/** If there are releases with multiple possible matches, we display a modal to make the user decide
  * which is the right one */
 function exportMultipleMatches() {
 
@@ -459,7 +459,7 @@ function exportMultipleMatches() {
                 imageURL = album.images[0].url;
             }
 
-            $('#spotifyDiv').append('<div><img src="' + imageURL + '" width="20%" style="display:inline-block; margin:10px; vertical-align:top"><div style="display:inline-block; width:70%"><h4>' + album.name + '</h4><button id="' + albumID + ' ' + imageURL + '" type="button" class="btn btn-success" onClick = "saveAlbumFromMulti(this.id)"><span class="icon-checkmark"></span> Choose this</button></div></div>');
+            $('#spotifyDiv').append('<div><img src="' + imageURL + '" width="20%" style="display:inline-block; margin:10px; vertical-align:top"><div style="display:inline-block; width:70%"><h4>' + name + '</h4><button id="' + albumID + ' ' + imageURL + '" type="button" class="btn btn-success" onClick = "saveAlbumFromMulti(this.id)"><span class="icon-checkmark"></span> Choose this</button></div></div>');
 
         });
 
@@ -514,13 +514,24 @@ function showNoMatch() {
 /** Start a search on Spotify and handle the result */
 function searchReleaseOnSpotify(release) {
 
+    var rArtist = releases.artistName;
+    if (rArtist) {
+        rArtist.replace('\'', ''); // there is a bug in spotify's search, apparently
+    }
     var rTitle = release.title;
+    var formatSuffixes = ['EP', 'E.P.', 'E.P', 'LP']
 
-    if (rTitle.endsWith("EP") || rTitle.endsWith("LP")) {
-        rTitle = rTitle.slice(0, -2).trim();
+    if (rTitle) {
+        rTitle.replace('\'', '');
+        for (var i = 0; i < formatSuffixes.length; i++) {
+            if (rTitle.endsWith(formatSuffixes[i])) {
+                rTitle = rTitle.slice(0, -formatSuffixes[i].length).trim();
+            }
+        }
     }
 
-    var query = 'album:"' + rTitle + '" artist:"' + release.artistName + '"';
+
+    var query = 'album:"' + rTitle + '" artist:"' + rArtist + '"';
 
     $.ajax({
         url: 'https://api.spotify.com/v1/search',
@@ -574,7 +585,7 @@ function handleResultFromSpotify(result, release) {
 
         var name = album.name;
 
-        //exact match 
+        //exact match
         if (!done && name.toLowerCase() === release.title.toLowerCase()) {
 
             done = true;

--- a/js/export.js
+++ b/js/export.js
@@ -516,13 +516,13 @@ function searchReleaseOnSpotify(release) {
 
     var rArtist = releases.artistName;
     if (rArtist) {
-        rArtist.replace('\'', ''); // there is a bug in spotify's search, apparently
+        rArtist = rArtist.replace('\'', ''); // there is a bug in spotify's search, apparently
     }
     var rTitle = release.title;
     var formatSuffixes = ['EP', 'E.P.', 'E.P', 'LP', 'L.P.',' L.P']
 
     if (rTitle) {
-        rTitle.replace('\'', '');
+        rTitle = rTitle.replace('\'', '');
         for (var i = 0; i < formatSuffixes.length; i++) {
             // ensure there is a leading space, so that potential acronym titles ("W.E.L.P.") do not get filtered out
             // this also prevents issues with releases such as "L.P." by "The Rembrandts"

--- a/js/export.js
+++ b/js/export.js
@@ -514,7 +514,7 @@ function showNoMatch() {
 /** Start a search on Spotify and handle the result */
 function searchReleaseOnSpotify(release) {
 
-    var rArtist = releases.artistName;
+    var rArtist = release.artistName;
     if (rArtist) {
         rArtist = rArtist.replace('\'', ''); // there is a bug in spotify's search, apparently
     }

--- a/js/export.js
+++ b/js/export.js
@@ -519,13 +519,14 @@ function searchReleaseOnSpotify(release) {
         rArtist.replace('\'', ''); // there is a bug in spotify's search, apparently
     }
     var rTitle = release.title;
-    var formatSuffixes = ['EP', 'E.P.', 'E.P', 'LP']
+    var formatSuffixes = ['EP', 'E.P.', 'E.P', 'LP', 'L.P.',' L.P']
 
     if (rTitle) {
         rTitle.replace('\'', '');
         for (var i = 0; i < formatSuffixes.length; i++) {
-            // only strip the suffix if it's not the full title (example "L.P." by "The Rembrandts")
-            if (rTitle.endsWith(formatSuffixes[i]) && rTitle.length > formatSuffixes[i].length) {
+            // ensure there is a leading space, so that potential acronym titles ("W.E.L.P.") do not get filtered out
+            // this also prevents issues with releases such as "L.P." by "The Rembrandts"
+            if (rTitle.endsWith(' ' + formatSuffixes[i])) {
                 rTitle = rTitle.slice(0, -formatSuffixes[i].length).trim();
                 break;
             }

--- a/js/export.js
+++ b/js/export.js
@@ -526,6 +526,7 @@ function searchReleaseOnSpotify(release) {
         for (var i = 0; i < formatSuffixes.length; i++) {
             if (rTitle.endsWith(formatSuffixes[i])) {
                 rTitle = rTitle.slice(0, -formatSuffixes[i].length).trim();
+                break;
             }
         }
     }

--- a/js/export.js
+++ b/js/export.js
@@ -524,7 +524,8 @@ function searchReleaseOnSpotify(release) {
     if (rTitle) {
         rTitle.replace('\'', '');
         for (var i = 0; i < formatSuffixes.length; i++) {
-            if (rTitle.endsWith(formatSuffixes[i])) {
+            // only strip the suffix if it's not the full title (example "L.P." by "The Rembrandts")
+            if (rTitle.endsWith(formatSuffixes[i]) && rTitle.length > formatSuffixes[i].length) {
                 rTitle = rTitle.slice(0, -formatSuffixes[i].length).trim();
                 break;
             }

--- a/js/export.js
+++ b/js/export.js
@@ -301,7 +301,7 @@ function addArtistsAndReleases(result) {
 
         //Some artists on Discogs have a number in closing round parenthesis behing their name. We don't want these.
         var splitName = releaseArtistName.split(/([(]\d+[)].*)/);
-        var artistName = splitName[0];
+        var artistName = splitName[0].trim();
 
         var thisRelease = new releaseObject(releaseTitle, artistName, releaseYear);
 


### PR DESCRIPTION
As a heavy discogs user with a collection of more than 2400 items, i love this. However, search matched only a fraction of my collection.
One issue is an apparent bug in Spotify's Search API, or at least an undocumented behaviour. Artist names or release titles with single quotes yield no results. Simply removing them works. You can verify this in Spotify's Developer Console with Artist "Vex'd", or the Album "If you're into it, I'm out of it" by "Christoph de Babalon".

I also have 33 releases that end with "E.P." rather an "EP", and 8 that end on "E.P". You'll also find many ending with "L.P." on Discogs.

Please note that I didn't test the resulting code, but i verified the improved search results in Spotify's Developer Console.