### PR TITLE
Strip quotes

### DIFF
--- a/js/export.js
+++ b/js/export.js
@@ -723,11 +723,11 @@ function saveAlbumTracks(tracks) {
     });
 }
 
-/** strips single quotes because Spotify's search cannot handle them  */
+/** strips single quotes because Spotify's search cannot consistently handle them */
 function stripSingleQuotes(string) {
     var strippedString = string.replace(/(\w)('\w*')(\w)/g, '$1 $2 $3'); // Twists'n'Turns => Twists 'n' Turns;
     strippedString = strippedString.replace(/'/g, '')
-    return strippedString.trim();
+    return strippedString;
 }
 
 /** Gets parameters from the hash of the URL */

--- a/js/export.js
+++ b/js/export.js
@@ -226,8 +226,8 @@ function getCollection(userName, page, getWantlist) {
         url: url,
         type: "GET",
         crossDomain: true,
-        data: { 
-            sort: "artist", 
+        data: {
+            sort: "artist",
             sort_order: "asc"
         },
         success: function (result) {
@@ -520,14 +520,13 @@ function searchReleaseOnSpotify(release) {
 
     var rArtist = release.artistName;
     if (rArtist) {
-        rArtist = rArtist.replace(/'/g, ''); // there is a bug in spotify's search, apparently
+        rArtist = stripSingleQuotes(rArtist);
     }
     var rTitle = release.title;
-    var formatSuffixes = ['EP', 'E.P.', 'E.P', 'LP', 'L.P.',' L.P']
+    var formatSuffixes = ['EP', 'E.P.', 'E.P', 'LP', 'L.P.',' L.P'];
 
     if (rTitle) {
-     	rTitle = rTitle.replace('\'n\'', ' n '); // Twists'n'Turns => Twists n Turns
-        rTitle = rTitle.replace(/'/g, '');
+        rTitle = stripSingleQuotes(rTitle);
         for (var i = 0; i < formatSuffixes.length; i++) {
             // ensure there is a leading space, so that potential acronym titles ("W.E.L.P.") do not get filtered out
             // this also prevents issues with releases such as "L.P." by "The Rembrandts"
@@ -681,7 +680,6 @@ function saveAlbumToPlaylist(albumID, imageURL) {
 
 }
 
-
 /** Saves tracks to the playlist */
 function saveAlbumTracks(tracks) {
 
@@ -725,6 +723,12 @@ function saveAlbumTracks(tracks) {
     });
 }
 
+/** strips single quotes because Spotify's search cannot handle them  */
+function stripSingleQuotes(string) {
+    var strippedString = string.replace(/(\w)('\w*')(\w)/g, '$1 $2 $3'); // Twists'n'Turns => Twists 'n' Turns;
+    strippedString = strippedString.replace(/'/g, '')
+    return strippedString.trim();
+}
 
 /** Gets parameters from the hash of the URL */
 function getHashParams() {

--- a/js/export.js
+++ b/js/export.js
@@ -725,7 +725,7 @@ function saveAlbumTracks(tracks) {
 
 /** strips single quotes because Spotify's search cannot consistently handle them */
 function stripSingleQuotes(string) {
-    var strippedString = string.replace(/(\w)('\w*')(\w)/g, '$1 $2 $3'); // Twists'n'Turns => Twists 'n' Turns;
+    var strippedString = string.replace(/(\w)('\w')(\w)/g, '$1 $2 $3'); // Twists'n'Turns => Twists 'n' Turns;
     strippedString = strippedString.replace(/'/g, '')
     return strippedString;
 }


### PR DESCRIPTION
this is a bit more generic, it looks for cases where two single quotes enclose a single character, but are not surrounded with spaces. it then adds surrounding spaces.  it does so more than once (regex mode), and for artist as well... at least 'r' is also common. example: https://www.discogs.com/ToysRNoise-ToysRNoise/master/681050

https://regex101.com/r/IpyC1O/4/