### PR TITLE
More matches

### DIFF
--- a/export.html
+++ b/export.html
@@ -27,7 +27,7 @@
 
     <!-- Custom CSS -->
     <link href="css/custom_style.css" rel="stylesheet">
-    
+
     <!-- Icons CSS -->
     <link href="css/icons.css" rel="stylesheet">
 
@@ -204,7 +204,7 @@
                     <h4 class="modal-title">Choose the best match</h4>
                 </div>
                 <div class="modal-body">
-                    <p style="color:black">We found more than one possible match on Spotify. Please choose from the list below:</p>
+                    <p style="color:black" id="bestMatchDetails">We found more than one possible match on Spotify. Please choose from the list below:</p>
                     <div id="matchfinder">
                         <div id="spotifyDiv">
                         </div>

--- a/export.html
+++ b/export.html
@@ -196,7 +196,7 @@
         </div>
     </div>
 
-    <!-- Modal: Coose best match -->
+    <!-- Modal: Choose best match -->
     <div id="bestMatch" class="modal fade">
         <div class="modal-dialog">
             <div class="modal-content">

--- a/js/export.js
+++ b/js/export.js
@@ -452,12 +452,12 @@ function exportMultipleMatches() {
 
 
         $('#bestMatchHeader').html("<h4 class='modal-title'>Choose the best match for <b>" + release.title + "</b> by " + release.artistName + yearString + "</h4>");
-        var matchDetails = 'There are ' + match.totalMatchCount + ' possible matches on Spotify.';
+        var matchDetails = 'There are ' + match.totalMatchCount + ' possible matches on Spotify. ';
         var searchLimit = 50;
         if (match.totalMatchCount > searchLimit) {
-            matchDetails = matchDetails.concat('Here are the first ' + searchLimit + '.');
+            matchDetails = matchDetails.concat('Here are the first ' + searchLimit + '. ');
         }
-        matchDetails = matchDetails.concat(' Please choose from the list below:');
+        matchDetails = matchDetails.concat('Please choose from the list below:');
         $('#bestMatchDetails').html(matchDetails);
 
         var matches = match.matches;

--- a/js/export.js
+++ b/js/export.js
@@ -170,9 +170,10 @@ function artist(name, releases) {
     this.releases = releases;
 }
 
-function multipleMatch(release, matches) {
+function multipleMatch(release, matches, totalMatchCount) {
     this.release = release;
     this.matches = matches;
+    this.totalMatchCount = totalMatchCount;
 }
 
 
@@ -226,8 +227,8 @@ function getCollection(userName, page, getWantlist) {
         url: url,
         type: "GET",
         crossDomain: true,
-        data: { 
-            sort: "artist", 
+        data: {
+            sort: "artist",
             sort_order: "asc"
         },
         success: function (result) {
@@ -443,6 +444,7 @@ function exportMultipleMatches() {
         multipleMatches.splice(0, 1);
 
         $('#bestMatchHeader').empty();
+        $('#bestMatchDetails').empty();
         $('#spotifyDiv').empty();
 
         var release = match.release;
@@ -450,6 +452,13 @@ function exportMultipleMatches() {
 
 
         $('#bestMatchHeader').html("<h4 class='modal-title'>Choose the best match for <b>" + release.title + "</b> by " + release.artistName + yearString + "</h4>");
+        var matchDetails = 'There are ' + match.totalMatchCount + ' possible matches on Spotify.';
+        var searchLimit = 50;
+        if (match.totalMatchCount > searchLimit) {
+            matchDetails = matchDetails.concat('Here are the first ' + searchLimit + '.');
+        }
+        matchDetails = matchDetails.concat(' Please choose from the list below:');
+        $('#bestMatchDetails').html(matchDetails);
 
         var matches = match.matches;
 
@@ -549,7 +558,8 @@ function searchReleaseOnSpotify(release) {
         data: {
             q: query,
             type: 'album',
-            market: userCountry
+            market: userCountry,
+            limit: 50
         },
         type: "GET",
         success: function (result) {
@@ -579,9 +589,10 @@ function handleResultFromSpotify(result, release) {
 
     //Possible matches
     var items = result.albums.items;
+    var total = result.albums.total;
 
     //nothing found
-    if (items.length === 0) {
+    if (total === 0) {
         withoutMatches.push(release);
         return;
     }
@@ -612,7 +623,7 @@ function handleResultFromSpotify(result, release) {
     });
 
     //One and only match - hope it's the right one
-    if (!done && items.length === 1) {
+    if (!done && total === 1) {
 
         done = true;
         var album = items[0];
@@ -630,9 +641,9 @@ function handleResultFromSpotify(result, release) {
     }
 
     //More than one possible match - let the user decide
-    if (!done && items.length > 1) {
+    if (!done && total > 1) {
 
-        var m = new multipleMatch(release, items);
+        var m = new multipleMatch(release, items, total);
         multipleMatches.push(m);
 
         done = true;


### PR DESCRIPTION
I have this album: https://www.discogs.com/Wunder-Wunder/release/23258
spotify returns 67 total potential hits for _artist:"wunder" album:"wunder"_, and it wasn't in the first 20 you presented me with (_limit_ defaults to 20 and is capped at 50). the irony is that this album is so obscure, and the title so generic, that it's also not in the first 50, it's literally match number 67... anyway, this will still help some users.

a more complex solution would need pagination and repeated search requests with an additional _offset_.

btw: if your search would also submit the release year in the search query, there would be exactly one match - the right one.
but i think always adding the year to searches would open a can of worms. users could own reissues etc, that spotify then maybe wouldn't find.